### PR TITLE
[fix] img_Url가져오는것을 url테이블에서 templestay_image로 변경

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestayRankingService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestayRankingService.java
@@ -19,6 +19,7 @@ public class TemplestayRankingService {
     private final CategoryRepository categoryRepository;
     private final WishlistRepository wishlistRepository;
     private final UrlRepository urlRepository;
+    private final TemplestayImageRepository templestayImageRepository;
 
     @Transactional
     public TemplestayRankingListRes getTopRankingList(Long userId) {
@@ -38,7 +39,7 @@ public class TemplestayRankingService {
 
                     String region = category != null ? CategoryUtils.getRegionName(category.getRegion()) : "알 수 없음";
 
-                    String imgUrl = urlRepository.findImgUrlByTemplestayId(id).orElse("이미지 없음");
+                    String imgUrl = templestayImageRepository.findImgUrlByTemplestayId(id).orElse("이미지 없음");
 
                     boolean liked = userId != null && wishlistRepository.existsByMemberIdAndTemplestayId(userId, id);
 

--- a/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestaySearchService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestaySearchService.java
@@ -12,10 +12,7 @@ import sopt.jeolloga.domain.member.core.Search;
 import sopt.jeolloga.domain.member.core.SearchRepository;
 import sopt.jeolloga.domain.templestay.api.dto.PageTemplestaySearchRes;
 import sopt.jeolloga.domain.templestay.api.dto.TemplestaySearchRes;
-import sopt.jeolloga.domain.templestay.core.Category;
-import sopt.jeolloga.domain.templestay.core.CategoryRepository;
-import sopt.jeolloga.domain.templestay.core.TemplestayRepository;
-import sopt.jeolloga.domain.templestay.core.UrlRepository;
+import sopt.jeolloga.domain.templestay.core.*;
 import sopt.jeolloga.domain.templestay.core.exception.TemplestayCoreException;
 import sopt.jeolloga.domain.wishlist.core.WishlistRepository;
 import sopt.jeolloga.exception.ErrorCode;
@@ -33,6 +30,7 @@ public class TemplestaySearchService {
     private final CategoryRepository categoryRepository;
     private final UrlRepository urlRepository;
     private final WishlistRepository wishlistRepository;
+    private final TemplestayImageRepository templestayImageRepository;
 
     @Transactional
     public PageTemplestaySearchRes<TemplestaySearchRes> searchTemplestay(Long userId, String query, int page, int pageSize) {
@@ -64,7 +62,7 @@ public class TemplestaySearchService {
                                 .orElseThrow(() -> new TemplestayCoreException(ErrorCode.NOT_FOUND_TARGET));
                         region = CategoryUtils.getRegionName(category.getRegion());
                         type = CategoryUtils.getTypeName(category.getType());
-                        imgUrl = urlRepository.findImgUrlByTemplestayId(id).orElse(null);
+                        imgUrl = templestayImageRepository.findImgUrlByTemplestayId(id).orElse(null);
                         if (userId != null) {
                             liked = wishlistRepository.existsByMemberIdAndTemplestayId(userId, id);
                         }

--- a/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayImage.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayImage.java
@@ -18,14 +18,14 @@ public class TemplestayImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "templestay_id")
-    private Long templestayId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "templestay_id")
+    private Templestay templestay;
 
     @Column(name = "img_url")
     private String imgUrl;
 
-    public TemplestayImage(Long templestayId, String imgUrl) {
-        this.templestayId = templestayId;
+    public TemplestayImage(String imgUrl) {
         this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayImageRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayImageRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TemplestayImageRepository extends JpaRepository<TemplestayImage, Long> {
+    @Query(value = "SELECT img_url FROM templestay_image WHERE templestay_id = :templestayId ORDER BY id ASC LIMIT 1", nativeQuery = true)
+    Optional<String> findImgUrlByTemplestayId(@Param("templestayId") Long templestayId);
 
     @Query("SELECT c FROM TemplestayImage c WHERE c.id IN :ids")
     List<TemplestayImage> findByIdIn(@Param("ids") List<Long> ids);

--- a/src/main/java/sopt/jeolloga/domain/templestay/core/UrlRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/core/UrlRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface UrlRepository extends JpaRepository<Url, Long> {
-    @Query("SELECT u.templestayUrl FROM Url u WHERE u.templestayId = :templestayId")
-    Optional<String> findImgUrlByTemplestayId(@Param("templestayId") Long templestayId);
     Optional<Url> findByTemplestayId(Long templestayId);
 
 }

--- a/src/main/java/sopt/jeolloga/domain/wishlist/api/service/WishlistService.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/api/service/WishlistService.java
@@ -28,6 +28,7 @@ public class WishlistService {
     private final TemplestayRepository templestayRepository;
     private final CategoryRepository categoryRepository;
     private final UrlRepository urlRepository;
+    private final TemplestayImageRepository templestayImageRepository;
 
     @Transactional
     public void addWishlist(Long userId, Long templestayId) {
@@ -77,7 +78,7 @@ public class WishlistService {
                     String region = CategoryUtils.getRegionName(category.getRegion());
                     String type = CategoryUtils.getTypeName(category.getType());
 
-                    String imgUrl = urlRepository.findImgUrlByTemplestayId(templestay.getId())
+                    String imgUrl = templestayImageRepository.findImgUrlByTemplestayId(templestay.getId())
                             .orElseThrow(() -> new WishlistNotFoundException());
 
                     boolean liked = wishlistRepository.existsByMemberIdAndTemplestayId(userId, templestay.getId());


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🛰️ Issue Number
---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
Issue #

### 🪐 작업 내용
---
- 템플스테이 관련된 이미지 불러오기가 전체적으로 url테이블에서 조회
- url테이블이 아닌 templestay_image에서 불러올수있도록 수정

```
@Query(value = "SELECT img_url FROM templestay_image WHERE templestay_id = :templestayId ORDER BY id ASC LIMIT 1", nativeQuery = true)
    Optional<String> findImgUrlByTemplestayId(@Param("templestayId") Long templestayId);
```

### 📚 Reference
---

### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?