### PR TITLE
[fix] 빈 문자열일 때 예외 제외 하고 검색결과 반환

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestaySearchService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/service/TemplestaySearchService.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static ch.qos.logback.core.joran.JoranConstants.NULL;
+
 @RequiredArgsConstructor
 @Service
 public class TemplestaySearchService {
@@ -43,7 +45,7 @@ public class TemplestaySearchService {
             saveSearchContent(userId, query);
         }
 
-        String sanitizedQuery = (query != null && !"NULL".equalsIgnoreCase(query)) ? query.trim() : "";
+        String sanitizedQuery = (query == null || query.isBlank()) ? "" : query.trim();
 
         Integer regionFilter = calculateBitValue(region, "region");
         Integer typeFilter = calculateBitValue(type, "type");
@@ -131,7 +133,7 @@ public class TemplestaySearchService {
     @Transactional
     private void saveSearchContent(Long userId, String content) {
         if (content == null || content.isBlank()) {
-            throw new TemplestayCoreException(ErrorCode.INVALID_SEARCH_CONTENT);
+            content = "";
         }
 
         Member member = null;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🛰️ Issue Number
---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
Issue #42 

### 🪐 작업 내용
---
- 기존에 content가 null이거나 빈 문자열일 때 예외처리 하던것을 응답값이 갈 수 있도록 반환
```
if (content == null || content.isBlank()) {
            content = "";
        }
```

### 📚 Reference
---

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?