### PR TITLE
[fix] filter 관련 type conversion 오류 해결

### DIFF
--- a/src/main/java/sopt/jeolloga/common/Filters.java
+++ b/src/main/java/sopt/jeolloga/common/Filters.java
@@ -139,11 +139,12 @@ public class Filters {
         int position = 0;
 
         for (String option : options) {
+            Object value = filterMap.get(option);
 
-            if((Integer) filterMap.get(option) == 1) {
+            if (value instanceof Integer && (Integer) value == 1) {
                 binaryValue |= (1 << position);
             }
-            position ++;
+            position++;
         }
 
         if(binaryValue == 0){

--- a/src/main/java/sopt/jeolloga/domain/templestay/api/service/FilterService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/service/FilterService.java
@@ -38,8 +38,6 @@ public class FilterService {
 
     public List<Long> getFiteredTemplestayCategory(TemplestayFilterReqTemp filter) {
 
-        // content 기반으로 id 필터링 + category 기반 필터링
-
         this.filters = new Filters(filter);
 
         List<Long> contentFilteredId = templestayRepository.findIdsByTempleNameContaining(filter.content());


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🛰️ Issue Number
---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->


### 🪐 작업 내용
프론트에서 filter 받아올 때,  Object type 변수로 가져와서 Integer로 변환 시 Null 값에 대한 예외 처리 진행

````java
public Integer convertToBinaryFilter(Map<String, Object> filterMap, List<String> options) {

        Integer binaryValue = 0;
        int position = 0;

        for (String option : options) {
            Object value = filterMap.get(option);

            if (value instanceof Integer && (Integer) value == 1) {  // Null 여부 체크
                binaryValue |= (1 << position);
            }
            position++;
        }

        if(binaryValue == 0){
            return Integer.MAX_VALUE;
        }
        return binaryValue;
    }
````


### 📚 Reference
---


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?