### PR TITLE
[fix] 최근검색어 목록 10개 반환 오류수정

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/member/core/SearchRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/member/core/SearchRepository.java
@@ -12,7 +12,12 @@ import java.util.List;
 
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
-    @Query(value = "SELECT s.id, s.content FROM search s WHERE s.member_id = :userId ORDER BY s.id DESC LIMIT 10", nativeQuery = true)
+    @Query(value = "SELECT s.id, s.content " +
+            "FROM search s " +
+            "WHERE s.member_id = :userId " +
+            "AND s.content <> '' " +
+            "ORDER BY s.id DESC " +
+            "LIMIT 10", nativeQuery = true)
     List<Object[]> findTop10ByMemberIdOrderByIdDesc(@Param("userId") Long userId);
 
     void deleteAllByMemberId(Long memberId);

--- a/src/main/java/sopt/jeolloga/domain/member/core/SearchRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/member/core/SearchRepository.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
-    @Query("SELECT s.id, s.content FROM Search s WHERE s.member.id = :userId ORDER BY s.id DESC")
-    List<Object[]> findTop10ByMemberIdOrderByIdDesc(Long userId);
+    @Query(value = "SELECT s.id, s.content FROM search s WHERE s.member_id = :userId ORDER BY s.id DESC LIMIT 10", nativeQuery = true)
+    List<Object[]> findTop10ByMemberIdOrderByIdDesc(@Param("userId") Long userId);
 
     void deleteAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🛰️ Issue Number
---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
Issue #

### 🪐 작업 내용
---
- 최근검색어 목록 전체 반환하는 오류 수정
- 10개로 제한해서 반환하도록 수정
```
@Query(value = "SELECT s.id, s.content FROM search s WHERE s.member_id = :userId ORDER BY s.id DESC LIMIT 10", nativeQuery = true)
    List<Object[]> findTop10ByMemberIdOrderByIdDesc(@Param("userId") Long userId);
```

### 📚 Reference
---

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?